### PR TITLE
update ruby to 2.4.5-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.2
+FROM ruby:2.4.5-alpine
 
 ENV LANG=C.UTF-8
 
@@ -6,16 +6,19 @@ WORKDIR /deployer
 
 ENV PATH=/deployer/bin:$PATH
 
-RUN curl -f -O https://storage.googleapis.com/kubernetes-release/release/v1.7.3/bin/linux/amd64/kubectl
-RUN chmod +x kubectl
+RUN apk add --no-cache --update curl git
+
 RUN mkdir bin
-RUN mv kubectl bin/kubectl
+RUN curl -f https://storage.googleapis.com/kubernetes-release/release/v1.7.3/bin/linux/amd64/kubectl > bin/kubectl && \
+    chmod +x bin/kubectl
 
 COPY Gemfile .
 COPY Gemfile.lock .
 RUN mkdir vendor
 COPY vendor/cache vendor/cache
-RUN bundle install --local
+RUN apk add --virtual build-base ruby-dev && \
+    bundle install --local && \
+    apk del build-base ruby-dev
 
 COPY . .
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '2.4.2'
+ruby '2.4.5'
 
 gem 'docker_registry2'
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ DEPENDENCIES
   timecop
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.4.5p335
 
 BUNDLED WITH
-   1.15.4
+   1.16.6

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Command do
           expect("that we don't get here because IOError was raised").
             to be true # this expectation is always false
         rescue IOError => error
-          expect(error.message).to eq "sh: 1: wtf: not found\n"
+          expect(error.message).to eq "sh: wtf: not found\n"
         end
       end
     end


### PR DESCRIPTION
decreased docker image size from 931MB to 155MB