### PR TITLE
tries to fix depctl

### DIFF
--- a/depctl/Dockerfile
+++ b/depctl/Dockerfile
@@ -1,5 +1,4 @@
-FROM ruby:2.4.0-slim
-RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+FROM ruby:2.6.3-slim
 RUN apt-get update && apt-get install -y git
 COPY depctl/bin/depctl.rb /usr/local/bin/
 COPY depctl/lib/trollop.rb /usr/local/lib/

--- a/depctl/Dockerfile
+++ b/depctl/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.4.0-slim
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
 RUN apt-get update && apt-get install -y git
 COPY depctl/bin/depctl.rb /usr/local/bin/
 COPY depctl/lib/trollop.rb /usr/local/lib/


### PR DESCRIPTION
Fix for the error on codeship: "W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)"